### PR TITLE
[Optimized]: Removed several bounds checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Benchmarks
 
 ```
 name              time/op
-Simple/ASCII-4     449ns ± 1%
-Simple/French-4    872ns ± 1%
-Simple/Nordic-4   1.74µs ± 1%
-Simple/Tibetan-4  1.34µs ± 1%
+Simple/ASCII-4     365ns ± 1%
+Simple/French-4    680ns ± 2%
+Simple/Nordic-4   1.33µs ± 2%
+Simple/Tibetan-4  1.15µs ± 2%
 
 name              alloc/op
 Simple/ASCII-4     96.0B ± 0%

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/agnivade/levenshtein
+
+go 1.13

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -43,10 +43,13 @@ func ComputeDistance(a, b string) int {
 
 	// init the row
 	x := make([]int, lenS1+1)
-	for i := 0; i <= lenS1; i++ {
+	for i := 0; i < len(x); i++ {
 		x[i] = i
 	}
 
+	// make a dummy bounds check to prevent the 2 bounds check down below.
+	// The one inside the loop is particularly costly.
+	_ = x[lenS1]
 	// fill in the rest
 	for i := 1; i <= lenS2; i++ {
 		prev := i


### PR DESCRIPTION
- For the init loop,  The compiler is unable to prove that
"<= lenS1" is essentially same as "< len(x)". So we mention it
explicitly.

- Made a dummy bounds check to prevent further checks for x[lenS1]
down below. And this also takes care of x[j-1] since j is <= lenS1.

This effectively reduces the number of bounds checks from 7 to just 1,
which is the dummy call to x[lenS1]. The compiler, as of 1.12,
is unable to determine that lenS1 is indeed a positive number. So
lenS1+1 will be positive, and hence x[lenS1] should be within bounds
of x. As a result, this is unavoidable.

```
name              old time/op  new time/op  delta
Simple/ASCII-4     473ns ± 2%   365ns ± 1%  -22.85%  (p=0.000 n=10+10)
Simple/French-4    897ns ± 2%   680ns ± 2%  -24.23%  (p=0.000 n=10+10)
Simple/Nordic-4   1.83µs ± 1%  1.33µs ± 2%  -27.23%  (p=0.000 n=8+9)
Simple/Tibetan-4  1.40µs ± 2%  1.15µs ± 2%  -17.56%  (p=0.000 n=10+10)
```