### PR TITLE
Optimize: skip setting zero during slice init

### DIFF
--- a/levenshtein.go
+++ b/levenshtein.go
@@ -43,7 +43,8 @@ func ComputeDistance(a, b string) int {
 
 	// init the row
 	x := make([]int, lenS1+1)
-	for i := 0; i < len(x); i++ {
+	// we start from 1 because index 0 is already 0.
+	for i := 1; i < len(x); i++ {
 		x[i] = i
 	}
 


### PR DESCRIPTION
Default value is already 0

Good enough improvement for a one character change.

```
name              old time/op    new time/op    delta
Simple/ASCII-4       380ns ± 3%     363ns ± 1%  -4.63%  (p=0.000 n=10+9)
Simple/French-4      694ns ± 2%     647ns ± 2%  -6.76%  (p=0.000 n=10+10)
Simple/Nordic-4     1.30µs ± 5%    1.24µs ± 6%  -4.34%  (p=0.027 n=10+10)
Simple/Tibetan-4    1.14µs ± 6%    1.09µs ± 1%  -4.40%  (p=0.000 n=10+9)

name              old alloc/op   new alloc/op   delta
Simple/ASCII-4       96.0B ± 0%     96.0B ± 0%    ~     (all equal)
Simple/French-4       128B ± 0%      128B ± 0%    ~     (all equal)
Simple/Nordic-4       192B ± 0%      192B ± 0%    ~     (all equal)
Simple/Tibetan-4      144B ± 0%      144B ± 0%    ~     (all equal)

name              old allocs/op  new allocs/op  delta
Simple/ASCII-4        1.00 ± 0%      1.00 ± 0%    ~     (all equal)
Simple/French-4       1.00 ± 0%      1.00 ± 0%    ~     (all equal)
Simple/Nordic-4       1.00 ± 0%      1.00 ± 0%    ~     (all equal)
Simple/Tibetan-4      1.00 ± 0%      1.00 ± 0%    ~     (all equal)
```