### PR TITLE
Use uint16 for storing count

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ levenshtein [![Build Status](https://travis-ci.org/agnivade/levenshtein.svg?bran
 The library is fully capable of working with non-ascii strings. But the strings are not normalized. That is left as a user-dependant use case. Please normalize the strings before passing it to the library if you have such a requirement.
 - https://blog.golang.org/normalization
 
+#### Limitation
+
+As a performance optimization, the library can handle strings only up to 65536 characters (runes). This is only available on tip, and is not part of a tagged release yet. If you require such an optimization, please use the version at tip.
+
 Install
 -------
 
@@ -38,10 +42,10 @@ Benchmarks
 
 ```
 name              time/op
-Simple/ASCII-4     365ns ± 1%
-Simple/French-4    680ns ± 2%
-Simple/Nordic-4   1.33µs ± 2%
-Simple/Tibetan-4  1.15µs ± 2%
+Simple/ASCII-4     330ns ± 2%
+Simple/French-4    617ns ± 2%
+Simple/Nordic-4   1.16µs ± 4%
+Simple/Tibetan-4  1.05µs ± 1%
 
 name              alloc/op
 Simple/ASCII-4     96.0B ± 0%

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -40,10 +40,10 @@ func ComputeDistance(a, b string) int {
 	lenS2 := len(s2)
 
 	// init the row
-	x := make([]int, lenS1+1)
+	x := make([]uint16, lenS1+1)
 	// we start from 1 because index 0 is already 0.
 	for i := 1; i < len(x); i++ {
-		x[i] = i
+		x[i] = uint16(i)
 	}
 
 	// make a dummy bounds check to prevent the 2 bounds check down below.
@@ -51,8 +51,8 @@ func ComputeDistance(a, b string) int {
 	_ = x[lenS1]
 	// fill in the rest
 	for i := 1; i <= lenS2; i++ {
-		prev := i
-		var current int
+		prev := uint16(i)
+		var current uint16
 		for j := 1; j <= lenS1; j++ {
 			if s2[i-1] == s1[j-1] {
 				current = x[j-1] // match
@@ -64,10 +64,10 @@ func ComputeDistance(a, b string) int {
 		}
 		x[lenS1] = prev
 	}
-	return x[lenS1]
+	return int(x[lenS1])
 }
 
-func min(a, b int) int {
+func min(a, b uint16) uint16 {
 	if a < b {
 		return a
 	}


### PR DESCRIPTION
A slice of uint16s fit more snugly in L1 cache and results in fewer misses.

Unfortunately, this limits the length of strings that can be used
to 65536.

Benchmark:
```
name              old time/op  new time/op  delta
Simple/ASCII-4     379ns ± 2%   330ns ± 2%  -13.03%  (p=0.000 n=10+10)
Simple/French-4    692ns ± 2%   617ns ± 2%  -10.75%  (p=0.000 n=10+10)
Simple/Nordic-4   1.28µs ± 1%  1.16µs ± 4%   -9.64%  (p=0.000 n=8+10)
Simple/Tibetan-4  1.16µs ± 3%  1.05µs ± 1%   -9.25%  (p=0.000 n=10+10)
```