### PR TITLE
Optimize: reduce allocs

### DIFF
--- a/levenshtein.go
+++ b/levenshtein.go
@@ -40,7 +40,11 @@ func ComputeDistance(a, b string) int {
 	lenS2 := len(s2)
 
 	// init the row
-	x := make([]uint16, lenS1+1)
+	x := make([]uint16, 0, 32)
+	if cap(x) < lenS1+1 {
+		x = make([]uint16, lenS1+1)
+	}
+	x = x[:lenS1+1]
 	// we start from 1 because index 0 is already 0.
 	for i := 1; i < len(x); i++ {
 		x[i] = uint16(i)

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -6,6 +6,11 @@ package levenshtein
 
 import "unicode/utf8"
 
+// minLengthThreshold is the length of the string beyond which
+// an allocation will be made. Strings smaller than this will be
+// zero alloc.
+const minLengthThreshold = 32
+
 // ComputeDistance computes the levenshtein distance between the two
 // strings passed as an argument. The return value is the levenshtein distance
 //
@@ -39,12 +44,19 @@ func ComputeDistance(a, b string) int {
 	lenS1 := len(s1)
 	lenS2 := len(s2)
 
-	// init the row
-	x := make([]uint16, 0, 32)
-	if cap(x) < lenS1+1 {
+	// Init the row.
+	var x []uint16
+	if lenS1+1 > minLengthThreshold {
 		x = make([]uint16, lenS1+1)
+	} else {
+		// We make a small optimization here for small strings.
+		// Because a slice of constant length is effectively an array,
+		// it does not allocate. So we can re-slice it to the right length
+		// as long as it is below a desired threshold.
+		x = make([]uint16, minLengthThreshold)
+		x = x[:lenS1+1]
 	}
-	x = x[:lenS1+1]
+
 	// we start from 1 because index 0 is already 0.
 	for i := 1; i < len(x); i++ {
 		x[i] = uint16(i)

--- a/levenshtein_test.go
+++ b/levenshtein_test.go
@@ -24,6 +24,7 @@ func TestSanity(t *testing.T) {
 		{"distance", "difference", 5},
 		{"levenshtein", "frankenstein", 6},
 		{"resume and cafe", "resumes and cafes", 2},
+		{"a very long string that is meant to exceed", "another very long string that is meant to exceed", 6},
 	}
 	for i, d := range tests {
 		n := agnivade.ComputeDistance(d.a, d.b)
@@ -69,6 +70,7 @@ func BenchmarkSimple(b *testing.B) {
 		// Testing acutes and umlauts
 		{"resumé and café", "resumés and cafés", "French"},
 		{"Hafþór Júlíus Björnsson", "Hafþor Julius Bjornsson", "Nordic"},
+		{"a very long string that is meant to exceed", "another very long string that is meant to exceed", "long string"},
 		// Only 2 characters are less in the 2nd string
 		{"།་གམ་འས་པ་་མ།", "།་གམའས་པ་་མ", "Tibetan"},
 	}


### PR DESCRIPTION
Use fixed size slice to reduce allocs.

```
benchmark                     old ns/op     new ns/op     delta
BenchmarkSimple/ASCII-8       324           294           -9.09%
BenchmarkSimple/French-8      620           584           -5.71%
BenchmarkSimple/Nordic-8      1187          1188          +0.08%
BenchmarkSimple/Tibetan-8     1044          1016          -2.68%

benchmark                     old allocs     new allocs     delta
BenchmarkSimple/ASCII-8       1              0              -100.00%
BenchmarkSimple/French-8      1              0              -100.00%
BenchmarkSimple/Nordic-8      1              0              -100.00%
BenchmarkSimple/Tibetan-8     1              0              -100.00%

benchmark                     old bytes     new bytes     delta
BenchmarkSimple/ASCII-8       24            0             -100.00%
BenchmarkSimple/French-8      32            0             -100.00%
BenchmarkSimple/Nordic-8      48            0             -100.00%
BenchmarkSimple/Tibetan-8     48            0             -100.00%

```