### PR TITLE
Improve performance and cleanup code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.22.x, 1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Lint
       run: make lint
     - name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agnivade/levenshtein
 
-go 1.13
+go 1.21
 
 require (
 	github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0
-	github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48
+	github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -71,7 +71,7 @@ func ComputeDistance(a, b string) int {
 		for j := 1; j <= lenS1; j++ {
 			current := x[j-1] // match
 			if s2[i-1] != s1[j-1] {
-				current = min(min(x[j-1]+1, prev+1), x[j]+1)
+				current = min(x[j-1]+1, prev+1, x[j]+1)
 			}
 			x[j-1] = prev
 			prev = current
@@ -79,11 +79,4 @@ func ComputeDistance(a, b string) int {
 		x[lenS1] = prev
 	}
 	return int(x[lenS1])
-}
-
-func min(a, b uint16) uint16 {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -41,6 +41,25 @@ func ComputeDistance(a, b string) int {
 	if len(s1) > len(s2) {
 		s1, s2 = s2, s1
 	}
+
+	// remove trailing identical runes.
+	for i := 0; i < len(s1); i++ {
+		if s1[len(s1)-1-i] != s2[len(s2)-1-i] {
+			s1 = s1[:len(s1)-i]
+			s2 = s2[:len(s2)-i]
+			break
+		}
+	}
+
+	// Remove leading identical runes.
+	for i := 0; i < len(s1); i++ {
+		if s1[i] != s2[i] {
+			s1 = s1[i:]
+			s2 = s2[i:]
+			break
+		}
+	}
+
 	lenS1 := len(s1)
 	lenS2 := len(s2)
 

--- a/levenshtein_test.go
+++ b/levenshtein_test.go
@@ -66,13 +66,35 @@ func BenchmarkSimple(b *testing.B) {
 		name string
 	}{
 		// ASCII
-		{"levenshtein", "frankenstein", "ASCII"},
+		{a: "levenshtein", b: "frankenstein", name: "ASCII"},
 		// Testing acutes and umlauts
-		{"resumé and café", "resumés and cafés", "French"},
-		{"Hafþór Júlíus Björnsson", "Hafþor Julius Bjornsson", "Nordic"},
-		{"a very long string that is meant to exceed", "another very long string that is meant to exceed", "long string"},
+		{a: "resumé and café", b: "resumés and cafés", name: "French"},
+		{a: "Hafþór Júlíus Björnsson", b: "Hafþor Julius Bjornsson", name: "Nordic"},
+
+		// Long strings
+		{
+			a:    "a very long string that is meant to exceed",
+			b:    "another very long string that is meant to exceed",
+			name: "Long lead",
+		},
+		{
+			a:    "a very long string with a word in the middle that is different",
+			b:    "a very long string with some text in the middle that is different",
+			name: "Long middle",
+		},
+		{
+			a:    "a very long string with some text at the end that is not the same",
+			b:    "a very long string with some text at the end that is very different",
+			name: "Long trail",
+		},
+		{
+			a:    "+a very long string with different leading and trailing characters+",
+			b:    "-a very long string with different leading and trailing characters-",
+			name: "Long diff",
+		},
+
 		// Only 2 characters are less in the 2nd string
-		{"།་གམ་འས་པ་་མ།", "།་གམའས་པ་་མ", "Tibetan"},
+		{a: "།་གམ་འས་པ་་མ།", b: "།་གམའས་པ་་མ", name: "Tibetan"},
 	}
 	tmp := 0
 	for _, test := range tests {


### PR DESCRIPTION
- remove leading and trailing identical runes before comparing
- use builtin min() function
- use supported Go versions, update actions to latest version in CI

Long strings with differences at the beginning (long_lead), in the middle (long_middle) or at the end (long_trail) show significant improvements in processing time and memory allocations. When the optimization is ineffective due to different leading and trailing characters (long_diff) there is no change in processing time or memory allocation.

```
goos: linux
goarch: amd64
pkg: github.com/agnivade/levenshtein
cpu: AMD Ryzen 7 7840U w/ Radeon  780M Graphics
                      │  before.txt  │              after.txt              │
                      │    sec/op    │   sec/op     vs base                │
Simple/ASCII-16         134.20n ± 0%   79.03n ± 0%  -41.11% (p=0.000 n=20)
Simple/French-16         254.8n ± 0%   129.7n ± 0%  -49.09% (p=0.000 n=20)
Simple/Nordic-16         500.6n ± 1%   208.0n ± 0%  -58.45% (p=0.000 n=20)
Simple/Long_lead-16     1862.0n ± 0%   209.6n ± 1%  -88.75% (p=0.000 n=20)
Simple/Long_middle-16   3613.0n ± 0%   325.0n ± 0%  -91.00% (p=0.000 n=20)
Simple/Long_trail-16    3911.0n ± 0%   399.0n ± 1%  -89.80% (p=0.000 n=20)
Simple/Long_diff-16      4.030µ ± 0%   4.029µ ± 1%        ~ (p=0.899 n=20)
Simple/Tibetan-16        413.0n ± 0%   277.3n ± 0%  -32.86% (p=0.000 n=20)
geomean                  964.6n        299.5n       -68.95%

                      │  before.txt  │              after.txt               │
                      │     B/op     │    B/op     vs base                  │
Simple/ASCII-16         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
Simple/French-16        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
Simple/Nordic-16        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
Simple/Long_lead-16     464.0 ± 0%     368.0 ± 0%  -20.69% (p=0.000 n=20)
Simple/Long_middle-16   672.0 ± 0%     544.0 ± 0%  -19.05% (p=0.000 n=20)
Simple/Long_trail-16    720.0 ± 0%     576.0 ± 0%  -20.00% (p=0.000 n=20)
Simple/Long_diff-16     720.0 ± 0%     720.0 ± 0%        ~ (p=1.000 n=20) ¹
Simple/Tibetan-16       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
geomean                            ²                -7.99%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                      │  before.txt  │              after.txt               │
                      │  allocs/op   │ allocs/op   vs base                  │
Simple/ASCII-16         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
Simple/French-16        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
Simple/Nordic-16        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
Simple/Long_lead-16     3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.000 n=20)
Simple/Long_middle-16   3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.000 n=20)
Simple/Long_trail-16    3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.000 n=20)
Simple/Long_diff-16     3.000 ± 0%     3.000 ± 0%        ~ (p=1.000 n=20) ¹
Simple/Tibetan-16       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
geomean                            ²               -14.11%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```