### PR TITLE
Hoist all bounds checks out of loops

### DIFF
--- a/levenshtein.go
+++ b/levenshtein.go
@@ -79,7 +79,7 @@ func ComputeDistance(a, b string) int {
 		for j := 0; j < lenS1; j++ {
 			current := x[j] // match
 			if s2[i] != s1[j] {
-				current = min(x[j]+1, prev+1, y[j]+1)
+				current = min(x[j], prev, y[j]) + 1
 			}
 			x[j] = prev
 			prev = current

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -43,22 +43,10 @@ func ComputeDistance(a, b string) int {
 	}
 
 	// remove trailing identical runes.
-	for i := 0; i < len(s1); i++ {
-		if s1[len(s1)-1-i] != s2[len(s2)-1-i] {
-			s1 = s1[:len(s1)-i]
-			s2 = s2[:len(s2)-i]
-			break
-		}
-	}
+	s1, s2 = trimLongestCommonSuffix(s1, s2)
 
 	// Remove leading identical runes.
-	for i := 0; i < len(s1); i++ {
-		if s1[i] != s2[i] {
-			s1 = s1[i:]
-			s2 = s2[i:]
-			break
-		}
-	}
+	s1, s2 = trimLongestCommonPrefix(s1, s2)
 
 	lenS1 := len(s1)
 	lenS2 := len(s2)
@@ -98,4 +86,24 @@ func ComputeDistance(a, b string) int {
 		x[lenS1] = prev
 	}
 	return int(x[lenS1])
+}
+
+func trimLongestCommonSuffix(a, b []rune) ([]rune, []rune) {
+	m := min(len(a), len(b))
+	a2 := a[len(a)-m:]
+	b2 := b[len(b)-m:]
+	i := len(a2)
+	b2 = b2[:i] // hoist bounds checks out of the loop
+	for ; i > 0 && a2[i-1] == b2[i-1]; i-- {
+		// deliberately empty body
+	}
+	return a[:len(a)-len(a2)+i], b[:len(b)-len(b2)+i]
+}
+
+func trimLongestCommonPrefix(a, b []rune) ([]rune, []rune) {
+	var i int
+	for m := min(len(a), len(b)); i < m && a[i] == b[i]; i++ {
+		// deliberately empty body
+	}
+	return a[i:], b[i:]
 }

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -69,18 +69,19 @@ func ComputeDistance(a, b string) int {
 		x[i] = uint16(i)
 	}
 
-	// make a dummy bounds check to prevent the 2 bounds check down below.
-	// The one inside the loop is particularly costly.
+	// hoist bounds checks out of the loops
 	_ = x[lenS1]
+	y := x[1:]
+	y = y[:lenS1]
 	// fill in the rest
-	for i := 1; i <= lenS2; i++ {
-		prev := uint16(i)
-		for j := 1; j <= lenS1; j++ {
-			current := x[j-1] // match
-			if s2[i-1] != s1[j-1] {
-				current = min(x[j-1]+1, prev+1, x[j]+1)
+	for i := 0; i < lenS2; i++ {
+		prev := uint16(i + 1)
+		for j := 0; j < lenS1; j++ {
+			current := x[j] // match
+			if s2[i] != s1[j] {
+				current = min(x[j]+1, prev+1, y[j]+1)
 			}
-			x[j-1] = prev
+			x[j] = prev
 			prev = current
 		}
 		x[lenS1] = prev

--- a/levenshtein_test.go
+++ b/levenshtein_test.go
@@ -122,18 +122,18 @@ func BenchmarkAll(b *testing.B) {
 	}
 	tmp := 0
 	for _, test := range tests {
-		b.Run(test.name, func(b *testing.B) {
-			b.Run("agniva", func(b *testing.B) {
+		b.Run("case="+test.name, func(b *testing.B) {
+			b.Run("impl=agniva", func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					tmp = agnivade.ComputeDistance(test.a, test.b)
 				}
 			})
-			b.Run("arbovm", func(b *testing.B) {
+			b.Run("impl=arbovm", func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					tmp = arbovm.Distance(test.a, test.b)
 				}
 			})
-			b.Run("dgryski", func(b *testing.B) {
+			b.Run("impl=dgryski", func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					tmp = dgryski.Levenshtein([]rune(test.a), []rune(test.b))
 				}


### PR DESCRIPTION
Some benchmark results (no changes in terms of allocations):

```text
$ benchstat -filter '.name:Simple' old new
goos: darwin
goarch: amd64
pkg: github.com/agnivade/levenshtein
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                     │     old     │                 new                 │
                     │   sec/op    │   sec/op     vs base                │
Simple/ASCII-8         167.5n ± 3%   142.4n ± 4%  -14.96% (p=0.000 n=20)
Simple/French-8        267.1n ± 2%   220.3n ± 3%  -17.49% (p=0.000 n=20)
Simple/Nordic-8        432.6n ± 2%   346.7n ± 3%  -19.86% (p=0.000 n=20)
Simple/Long_lead-8     326.2n ± 0%   275.9n ± 0%  -15.41% (p=0.000 n=20)
Simple/Long_middle-8   520.4n ± 0%   441.6n ± 0%  -15.15% (p=0.000 n=20)
Simple/Long_trail-8    721.6n ± 0%   608.3n ± 0%  -15.70% (p=0.000 n=20)
Simple/Long_diff-8     8.549µ ± 1%   6.537µ ± 0%  -23.53% (p=0.000 n=20)
Simple/Tibetan-8       562.1n ± 2%   493.3n ± 3%  -12.25% (p=0.000 n=20)
geomean                571.6n        475.2n       -16.86%
```